### PR TITLE
Change the macOS app identifiers

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -9,11 +9,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>????</string>
+	<string>rref</string>
 	<key>CFBundleExecutable</key>
 	<string>ricochet-refresh</string>
 	<key>CFBundleIdentifier</key>
-	<string>im.ricochet</string>
+	<string>net.blueprintforfreespeech.ricochet-refresh</string>
 	<key>CFBundleName</key>
 	<string>Ricochet-Refresh</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>


### PR DESCRIPTION
Users may need to open the legacy Ricochet and Ricochet Refresh at the
same time, so they can manually transfer contacts. So on macOS, Ricochet
Refresh should have a new CFBundleIdentifier and CFBundleSignature.

For details, see:
https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW19