### PR TITLE
Update ricochet refresh to have a new CFBundleIdentifier

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleExecutable</key>
 	<string>ricochet-refresh</string>
 	<key>CFBundleIdentifier</key>
-	<string>im.ricochet</string>
+	<string>net.ricochetrefresh</string>
 	<key>CFBundleName</key>
 	<string>Ricochet-Refresh</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>


### PR DESCRIPTION
CFBundleSignature does not need to be updated as versions of macOS >10.7 ignore this field